### PR TITLE
add underscore.string dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
+var _ = {};
+_.str = require('underscore.string');
 
 // Returns false if the directory doesn't exist
 module.exports = function requireAll(options) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "require",
     "directory"
   ],
+  "dependencies": {
+    "underscore.string": "2.3.1"
+  },
   "author": "felixge+thlorenz, adapted by Mike McNeil",
   "license": "MIT",
   "readmeFilename": "Readme.md"


### PR DESCRIPTION
`underscore.string` is used but never declared as a dependency.

Works in Sails because of the globals.
