### PR TITLE
add useModuleName option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function requireAll(options) {
     options.force = true;
   }
 
+  if (typeof(options.useModuleName) == 'undefined') {
+    options.useModuleName = false;
+  }
+
   // Sane default for `filter` option
   if (!options.filter) {
     options.filter = /(.*)/;
@@ -126,7 +130,14 @@ module.exports = function requireAll(options) {
           var resolved = require.resolve(filepath);
           if (require.cache[resolved]) delete require.cache[resolved];
         }
-        modules[identity] = require(filepath);
+        var requiredModule = require(filepath);
+        if (options.useModuleName &&
+            typeof(requiredModule.name) != "undefined" &&
+            requiredModule.name != '') {
+          modules[requiredModule.name] = requiredModule;
+        } else {
+          modules[identity] = requiredModule;
+        }
       }
     }
   });

--- a/test/pages/login_page.js
+++ b/test/pages/login_page.js
@@ -1,0 +1,3 @@
+module.exports = function LoginPage() {
+  return 'classy things';
+}

--- a/test/pages/noname_page.js
+++ b/test/pages/noname_page.js
@@ -1,0 +1,2 @@
+var NoName = function() { return 'not named!'};
+module.exports = NoName;

--- a/test/pages/root_page.js
+++ b/test/pages/root_page.js
@@ -1,0 +1,5 @@
+var RootPage = (function() {
+  function RootPage() { return 'some useful ctor';}
+  return RootPage;
+})();
+module.exports = RootPage;

--- a/test/test.js
+++ b/test/test.js
@@ -65,3 +65,13 @@ var excludedSvnAndSub = requireAll({
 assert.equal(excludedSvnAndSub['.svn'], undefined);
 assert.ok(excludedSvnAndSub['root']);
 assert.equal(excludedSvnAndSub['sub'], undefined);
+
+var useModuleName = requireAll({
+  dirname: __dirname + '/pages',
+  useModuleName: true,
+  filter: /(.+_page)\.js$/
+});
+
+assert.equal(typeof useModuleName.RootPage, 'function');
+assert.equal(typeof useModuleName.LoginPage, 'function');
+assert.notEqual(typeof useModuleName[''], 'function');


### PR DESCRIPTION
Adds an option to use exported function names as the result of requiring a file that exports a single class. See test additions for an example.
