### PR TITLE
Adds an option so that the file result can be sorted

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,13 @@ module.exports = function requireAll(options) {
     else throw new Error('Directory not found: ' + options.dirname);
   }
 
+  // Sort the result
+  if (!!options.sortResult) {
+    files = files.sort(function(a, b) {
+      return a < b ? -1 : 1;
+    });
+  }
+
   // Iterate through files in the current directory
   files.forEach(function(file) {
     var filepath = options.dirname + '/' + file;


### PR DESCRIPTION
This can be used later when loading the hooks with sails-build-dictionary, so that the hooks are loaded in order. A very rudimentary solution for setting order/dependencies for hooks