### PR TITLE
Also check to avoid symbolic link

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function requireAll(options) {
     var filepath = options.dirname + '/' + file;
 
     // For directories, continue to recursively include modules
-    if (fs.statSync(filepath).isDirectory()) {
+    if (!fs.lstatSync(filepath).isSymbolicLink() && fs.statSync(filepath).isDirectory()) {
 
       // Ignore explicitly excluded directories
       if (excludeDirectory(file)) return;


### PR DESCRIPTION
Skipping symlinks seems safest as otherwise, given most common usage, a link could lead to a circular reference.