### PR TITLE
Revising implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
 var fs = require('fs');
 var ltrim = require('underscore.string').ltrim;
-var object = require('underscore.object');
-var extend = object.extend;
-var isEmpty = object.isEmpty;
-var isFn = object.isFunction;
 
 
 module.exports = function requireAll(options) {
@@ -118,4 +114,22 @@ function collectLevel( context, modules, pathName, currentDepth, flattening ) {
   });
 
   return modules;
+}
+
+function extend( target ) {
+  for ( var arg, i = 1, l = arguments.length; i < l; i++ ) {
+    arg = arguments[i] || {};
+    Object.keys( arg )
+        .forEach( function( name ) { target[name] = arg[name]; } );
+  }
+
+  return target;
+}
+
+function isEmpty( value ) {
+  return !value || ( typeof value == "object" && !Object.keys( value ).length );
+}
+
+function isFn( value ) {
+  return typeof value === "function";
 }


### PR DESCRIPTION
Revision is
- extracting initialization code from recursively called method. 
- stopping to copy objects to objects that often while diving into file system. 
- trying to use existing objects as much as possible instead. 
- preparing callbacks replacing recurring static decisions while processing recursively.
- using more common pattern for managing default options (simplifying additional future revisions).
- adding support for requireAll-like invocation using string only.
- enabling optional use of callback instead of RegExp in options `excludeDirs`, `filter` and `pathFilter`.
- flattening directories inline while traversing file system (previous approach was flattening over and over again each time bubbling from a sub directory ... copying objects to objects ...).
- passing rare set of previously existing tests.
