### PR TITLE
Use `path.basename()` to recursively add directory names to filenames when using `keepDirectoryPath`

### DIFF
--- a/lib/help-include-all-sync.js
+++ b/lib/help-include-all-sync.js
@@ -211,7 +211,7 @@ module.exports = function includeAll(options) {
           _.each(descendantModules, function (rhs, grandchildKey){
 
             if (options.keepDirectoryPath) {
-              _modules[path.join(relativePath, grandchildKey)] = rhs;
+              _modules[path.join(path.basename(relativePath), grandchildKey)] = rhs;
             }
             else {
               if (_modules[grandchildKey]) { throw new Error('Attempting to flatten modules but duplicate key detected (`'+grandchildKey+'`).  Enable `keepDirectoryPath: true` to enable namepspacing based on hierarchy.'); }

--- a/test/fixtures/lowlvl/controllers/level1/level2/level3/nestedController.js
+++ b/test/fixtures/lowlvl/controllers/level1/level2/level3/nestedController.js
@@ -1,0 +1,1 @@
+exports.nestingLevel = 3;

--- a/test/lowlvl-sync-usage.test.js
+++ b/test/lowlvl-sync-usage.test.js
@@ -27,6 +27,16 @@ describe('basic usage of synchronous, low-level function', function(){
       'other-Controller': {
         index: 1,
         show: 'nothing'
+      },
+
+      'level1': {
+        'level2': {
+          'level3': {
+            'nestedController': {
+              nestingLevel: 3
+            }
+          }
+        }
       }
     });
 
@@ -77,6 +87,67 @@ describe('basic usage of synchronous, low-level function', function(){
     assert.equal(excludedSvnAndSub['sub'], undefined);
 
   });//</it should have loaded stuff as expected>
+
+  describe('with flatten: true and keepDirectoryPath: false', function() {
+
+    it('should flatten nested folders into one level', function (){
+      var controllers = includeAll({
+        dirname: __dirname + '/fixtures/lowlvl/controllers',
+        filter: /(.+Controller)\.js$/,
+        flatten: true
+      });
+
+      assert.deepEqual(controllers, {
+        'main-Controller': {
+          index: 1,
+          show: 2,
+          add: 3,
+          edit: 4
+        },
+
+        'other-Controller': {
+          index: 1,
+          show: 'nothing'
+        },
+
+        'nestedController': {
+          nestingLevel: 3
+        }
+      });
+    });
+
+  });
+
+  describe('with flatten: true and keepDirectoryPath: true', function() {
+
+    it('should flatten nested folders into one level, keeping the directory path as part of the identity', function (){
+      var controllers = includeAll({
+        dirname: __dirname + '/fixtures/lowlvl/controllers',
+        filter: /(.+Controller)\.js$/,
+        flatten: true,
+        keepDirectoryPath: true
+      });
+
+      assert.deepEqual(controllers, {
+        'main-Controller': {
+          index: 1,
+          show: 2,
+          add: 3,
+          edit: 4
+        },
+
+        'other-Controller': {
+          index: 1,
+          show: 'nothing'
+        },
+
+        'level1/level2/level3/nestedController': {
+          nestingLevel: 3
+        }
+      });
+    });
+
+  });
 
 });//</describe :: basic usage of synchronous, low-level function>
 


### PR DESCRIPTION
Otherwise `api/controllers/level1/level2/level3/FooController.js` ends up with identity `level1/level1/level2/level1/level2/level3/foo`, because the directory name snowballs.