### PR TITLE
Map default export to module for es-module interoperability

### DIFF
--- a/lib/help-include-all-sync.js
+++ b/lib/help-include-all-sync.js
@@ -290,7 +290,9 @@ module.exports = function includeAll(options) {
 
           // Require the module.
           try {
-            _modules[keyName] = require(filepath);
+            var _module = require(filepath)
+            if (_module.default) { _module = _module.default }
+            _modules[keyName] = _module;
           } catch (e) {
             // Skip this module silently if `ignoreRequireFailures` is enabled.
             if (options.ignoreRequireFailures) { return; }

--- a/test/esmodules.test.js
+++ b/test/esmodules.test.js
@@ -1,0 +1,32 @@
+/**
+ * Module dependencies
+ */
+
+var assert = require('assert');
+var path = require('path');
+var loader = require('../');
+
+
+
+describe('es modules, default is a default export', function(){
+
+
+  it('should return the default export as default - lowlevel', function () {
+
+    var modules = loader({
+      dirname: path.resolve(__dirname, './fixtures/es-modules'),
+      filter: /(.+\.js)$/
+    })
+
+    assert.deepEqual(modules, {
+      'module-default.js': true,
+      'sub-dir': {
+        'another-module.js': true
+      }
+    });
+
+  });//</should return the default export as default - lowlevel>
+
+
+});//</describe>
+

--- a/test/fixtures/es-modules/module-default.js
+++ b/test/fixtures/es-modules/module-default.js
@@ -1,0 +1,2 @@
+
+exports.default = true

--- a/test/fixtures/es-modules/sub-dir/another-module.js
+++ b/test/fixtures/es-modules/sub-dir/another-module.js
@@ -1,0 +1,2 @@
+
+exports.default = true


### PR DESCRIPTION
Using es modules (i.e., using `@std/esm`) doesn't work very well with Sails.  Most things that sails magically requires are run through this module and it doesn't account for a default export from an es module.

When using the following syntax in, e.g., `./api/policies/dummy.js`:

```js
export default (req, res, next) => next()
````

Sails will issue the following complaint: 

```
In ${controller} ignored invalid attempt to bind route to a non-function controller: { default: [Function: wrapper],
  identity: 'dummy',
  globalId: 'dummy',
  etc...
```

And an error will be thrown attempting to call `_.bind` on `{default: [Function: wrapper]}`  (TypeError: Expected a Function).

This can apply to config files as well.... the `./config/*.js` aren't really a problem as they use named exports -- this is more for in `./config/env/*.js` which the sails generator create as default exports.

This PR attempts to rectify this globally for sails by mapping `module.default` to `module`, if it exists.  This will allow for interoperability with es-modules in sails applications.
