### PR TITLE
Map default export to module for es-module interoperability - 1.x branch

### DIFF
--- a/lib/help-include-all-sync.js
+++ b/lib/help-include-all-sync.js
@@ -268,7 +268,9 @@ module.exports = function includeAll(options) {
 
           // Require the module.
           try {
-            _modules[keyName] = require(filepath);
+            var _module = require(filepath)
+            if (_module.default) { _module = _module.default }
+            _modules[keyName] = _module;
           } catch (e) {
             // Skip this module silently if `ignoreRequireFailures` is enabled.
             if (options.ignoreRequireFailures) { return; }

--- a/test/esmodules.test.js
+++ b/test/esmodules.test.js
@@ -1,0 +1,32 @@
+/**
+ * Module dependencies
+ */
+
+var assert = require('assert');
+var path = require('path');
+var loader = require('../');
+
+
+
+describe('es modules, default is a default export', function(){
+
+
+  it('should return the default export as default - lowlevel', function () {
+
+    var modules = loader({
+      dirname: path.resolve(__dirname, './fixtures/es-modules'),
+      filter: /(.+\.js)$/
+    })
+
+    assert.deepEqual(modules, {
+      'module-default.js': true,
+      'sub-dir': {
+        'another-module.js': true
+      }
+    });
+
+  });//</should return the default export as default - lowlevel>
+
+
+});//</describe>
+

--- a/test/fixtures/es-modules/module-default.js
+++ b/test/fixtures/es-modules/module-default.js
@@ -1,0 +1,2 @@
+
+exports.default = true

--- a/test/fixtures/es-modules/sub-dir/another-module.js
+++ b/test/fixtures/es-modules/sub-dir/another-module.js
@@ -1,0 +1,2 @@
+
+exports.default = true

--- a/test/lowlvl-sync-usage.test.js
+++ b/test/lowlvl-sync-usage.test.js
@@ -129,7 +129,10 @@ describe('basic usage of synchronous, low-level function', function(){
         keepDirectoryPath: true
       });
 
-      assert.deepEqual(controllers, {
+      var nestKey = path.join('level1', 'level2', 'level3', 'nestedController');
+
+      var expected = {
+
         'main-Controller': {
           index: 1,
           show: 2,
@@ -140,12 +143,13 @@ describe('basic usage of synchronous, low-level function', function(){
         'other-Controller': {
           index: 1,
           show: 'nothing'
-        },
-
-        'level1/level2/level3/nestedController': {
-          nestingLevel: 3
         }
-      });
+
+      };
+
+      expected[nestKey] = { nestingLevel: 3};
+
+      assert.deepEqual(controllers, expected);
     });
 
   });


### PR DESCRIPTION
See #20 for more details.

This is against the 1.x branch so it can be pulled in on `sails@latest`

I also cherry-picked the commit for fixing tests on Windows.
